### PR TITLE
fix? `npm install gulp-htmlmin --save-dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > Minify HTML.
 
 ## Getting Started
-Install the module with: `npm install gulp-htmlmin`
+Install the module with: `npm install gulp-htmlmin --save-dev`
 
 ## Usage
 


### PR DESCRIPTION
Wouldn't you (or most people) want to add to package.json?  Or do you think it is better to list the 3 ways to instal?
Or do you have a secret dev-trick for leaving off `--save-dev`?
