### PR TITLE
Bump html-minifier to enable JS/CSS minification.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "event-stream": "~3.0.20",
-    "html-minifier": "~0.5.4",
+    "html-minifier": "~0.6.0",
     "gulp-util": "~2.2.14"
   },
   "keywords": [


### PR DESCRIPTION
CSS minification was introduced in `html-minifier` 0.6.0, bump the version to enable the `minifyJS` and `minifyCSS` options.

Should also fix https://github.com/jonschlinkert/gulp-htmlmin/issues/7
