### PR TITLE
Fix for #47: htmlmin reordering elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bufferstreams": "^1.1.0",
     "gulp-util": "^3.0.7",
-    "html-minifier": "^1.3.0",
+    "html-minifier": "^1.3.1",
     "object-assign": "^4.0.1",
     "readable-stream": "^2.0.2",
     "tryit": "^1.0.1"


### PR DESCRIPTION
Bumped html-minifier to 1.3.1 as it fixes a problematic issue with unknown HTML tags (e.g. AngularJS directive tags).