### PR TITLE
Use native Object.assign

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 var BufferStreams = require('bufferstreams');
 var htmlmin = require('html-minifier');
 var gutil = require('gulp-util');
-var objectAssign = require('object-assign');
 var Transform = require('readable-stream/transform');
 var tryit = require('tryit');
 
@@ -22,7 +21,7 @@ module.exports = function gulpHtmlmin(options) {
           result = new Buffer(htmlmin.minify(String(buf), options));
         }, function(err) {
           if (err) {
-            options = objectAssign({}, options, {fileName: file.path});
+            options = Object.assign({}, options, {fileName: file.path});
             done(new gutil.PluginError('gulp-htmlmin', err, options));
             return;
           }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "bufferstreams": "^1.1.0",
     "gulp-util": "^3.0.7",
     "html-minifier": "^3.0.3",
-    "object-assign": "^4.0.1",
     "readable-stream": "^2.0.2",
     "tryit": "^1.0.1"
   },


### PR DESCRIPTION
Replaces and removes the need for the object-assign module.

Closes #70.