### PR TITLE
Replace deprecated gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@
 
 var BufferStreams = require('bufferstreams');
 var htmlmin = require('html-minifier');
-var gutil = require('gulp-util');
 var objectAssign = require('object-assign');
+var PluginError = require('plugin-error');
 var Transform = require('readable-stream/transform');
 var tryit = require('tryit');
 
@@ -23,7 +23,7 @@ module.exports = function gulpHtmlmin(options) {
         }, function(err) {
           if (err) {
             options = objectAssign({}, options, {fileName: file.path});
-            done(new gutil.PluginError('gulp-htmlmin', err, options));
+            done(new PluginError('gulp-htmlmin', err, options));
             return;
           }
           done(null, result);

--- a/package.json
+++ b/package.json
@@ -30,9 +30,9 @@
   },
   "dependencies": {
     "bufferstreams": "^1.1.0",
-    "gulp-util": "^3.0.7",
     "html-minifier": "^3.0.3",
     "object-assign": "^4.0.1",
+    "plugin-error": "^0.1.2",
     "readable-stream": "^2.0.2",
     "tryit": "^1.0.1"
   },


### PR DESCRIPTION
`gulp-util` is deprecated. To future-proof this module, I replaced `gutil.PluginErrror` with `plugin-error`.