### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
   - '8'
   - '7'
   - '6'
-  - '5'
-  - '4'
 git:
   depth: 1
 branches:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "html-minifier": "^3.5.20",
+    "html-minifier": "^4.0.0",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
   "dependencies": {
     "html-minifier": "^4.0.0",
     "plugin-error": "^1.0.1",
-    "through2": "^2.0.3"
+    "through2": "^3.0.1"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
-    "gulp-format-md": "^1.0.0",
-    "mocha": "^5.2.0",
+    "gulp": "^4.0.0",
+    "gulp-format-md": "^2.0.0",
+    "mocha": "^6.1.1",
     "vinyl": "^2.2.0"
   },
   "keywords": [


### PR DESCRIPTION
The first commit updates `html-minifier` to 4.0.0.  This new version of html-minifier was semver-major due to it now requiring node.js 6.

The second commit updates through2 and all dev dependencies.  I did this as a separate commit in case you do not want the through2 upgrade it'll be easier to remove.

I verified locally that tests pass against node.js 6 for both commits.