### PR TITLE
Move to html-minifier-terser to support ES6 🔧

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,1 +1,1 @@
-<!-- HEADS UP! This library simply wraps [html-minifier](https://github.com/kangax/html-minifier). Please report all issues related to HTML parsing and output to the html-minifier issue tracker. -->
+<!-- HEADS UP! This library simply wraps [html-minifier-terser](https://github.com/DanielRuf/html-minifier-terser). Please report all issues related to HTML parsing and output to the html-minifier-terser issue tracker. -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
   - '8'
   - '7'
   - '6'
-  - '5'
-  - '4'
 git:
   depth: 1
 branches:

--- a/.verb.md
+++ b/.verb.md
@@ -1,10 +1,10 @@
 ## Heads up!
 
-_**Please do not report issues related to HTML parsing and output on this repository. Report those issues to the [html-minifier](https://github.com/kangax/html-minifier/issues) issue tracker.**_
+_**Please do not report issues related to HTML parsing and output on this repository. Report those issues to the [html-minifier-terser](https://github.com/DanielRuf/html-minifier-terser/issues) issue tracker.**_
 
 ## Usage
 
-See the [html-minifer docs](https://github.com/kangax/html-minifier) for all available options.
+See the [html-minifier-terser docs](https://github.com/DanielRuf/html-minifier-terser) for all available options.
 
 ```js
 const gulp = require('gulp');

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ $ npm install --save gulp-htmlmin
 
 ## Heads up!
 
-_**Please do not report issues related to HTML parsing and output on this repository. Report those issues to the [html-minifier](https://github.com/kangax/html-minifier/issues) issue tracker.**_
+_**Please do not report issues related to HTML parsing and output on this repository. Report those issues to the [html-minifier-terser](https://github.com/DanielRuf/html-minifier-terser/issues) issue tracker.**_
 
 ## Usage
 
-See the [html-minifer docs](https://github.com/kangax/html-minifier) for all available options.
+See the [html-minifier-terser docs](https://github.com/DanielRuf/html-minifier-terser) for all available options.
 
 ```js
 const gulp = require('gulp');

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const PluginError = require('plugin-error');
-const htmlmin = require('html-minifier');
+const htmlmin = require('html-minifier-terser');
 const through = require('through2');
 
 module.exports = options => {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "html-minifier": "^3.5.20",
+    "html-minifier-terser": "^5.0.0",
     "plugin-error": "^1.0.1",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
As debated [in this thread](https://github.com/kangax/html-minifier/issues/1040) `html-minifier` is using `uglify-js` which doesnt support ES6, so if you have any ES6 in your HTML it doesnt compress it.

This new fork created by @DanielRuf changes `uglify-js` to the latest `terser` version.

This change is really need nowadays since if you include even 1 line of ES6 the whole JS does not compress.

P.S. I can send another PR bumping this package version if you want. (Nothing should break but since this is a big change I would bump to 6.0.0)